### PR TITLE
Fixed small bug where mundane NPC's sheet wouldn't open

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -59,16 +59,17 @@ export class CainActorSheet extends ActorSheet {
         relativeTo: this.actor,
       }
     );
-
-    context.enrichedDescription = await TextEditor.enrichHTML(
-      this.actor.system.severeAttack.description  || this.actor.system.attack.description,
-      {
-        secrets: this.document.isOwner,
-        async: true,
-        rollData: this.actor.getRollData(),
-        relativeTo: this.actor,
-      }
-    );
+    if (this.actor.system.severeAttack || this.actor.system.attack) {
+      context.enrichedDescription = await TextEditor.enrichHTML(
+        this.actor.system.severeAttack.description  || this.actor.system.attack.description,
+        {
+          secrets: this.document.isOwner,
+          async: true,
+          rollData: this.actor.getRollData(),
+          relativeTo: this.actor,
+        }
+      );
+    }
 
     context.effects = prepareActiveEffectCategories(
       this.actor.allApplicableEffects()

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/cain/assets/cain.png"
     }
   ],
-  "version": "1.0.21",
+  "version": "1.0.22",
   "compatibility": {
     "minimum": 11,
     "verified": "12"


### PR DESCRIPTION
Foundry wasn't opening mundane NPCs since they didn't have a description for their severe attack.  Added a check before registering to make sure that attacks exist.  

This will also merge in some changes from main that weren't on development.