### PR TITLE
Fixed Severe Attack bug with uninitialized sin sheets

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -59,9 +59,21 @@ export class CainActorSheet extends ActorSheet {
         relativeTo: this.actor,
       }
     );
-    if (this.actor.system.severeAttack || this.actor.system.attack) {
+    if (this.actor.system.severeAttack) {
       context.enrichedDescription = await TextEditor.enrichHTML(
-        this.actor.system.severeAttack.description  || this.actor.system.attack.description,
+        this.actor.system.severeAttack.description,
+        {
+          secrets: this.document.isOwner,
+          async: true,
+          rollData: this.actor.getRollData(),
+          relativeTo: this.actor,
+        }
+      );
+    }
+
+    if (this.actor.system.attack) {
+      context.enrichedDescription = await TextEditor.enrichHTML(
+        this.actor.system.attack.description,
         {
           secrets: this.document.isOwner,
           async: true,

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/cain/assets/cain.png"
     }
   ],
-  "version": "1.0.22",
+  "version": "1.0.23",
   "compatibility": {
     "minimum": 11,
     "verified": "12"


### PR DESCRIPTION
If the sin sheets weren't initialized, they wouldn't open either due to not having a description/severe attack.

I think these bugs highlight the need for separating out some of the logic so that we can run it on a per-type basis.