### PR TITLE
Aesthetic updates

### DIFF
--- a/css/cain.css
+++ b/css/cain.css
@@ -737,7 +737,6 @@
 }
 
 .mob-psycho-header-fields {
-  background-color: #262626;
   padding: 10px;
   border-radius: 5px;
 }
@@ -816,8 +815,6 @@
 
 .mob-psycho-tab {
   background-color: #0d0d0d;
-  padding: 10px;
-  border: 1px solid #00bfff; /* Jujutsu Kaisen inspired accent color */
 }
 
 .mob-psycho-sidebar {
@@ -858,7 +855,7 @@
   background-color: #1a1a1a;
   padding: 10px;
   border-radius: 5px;
-  border: 2px solid #00bfff; /* Jujutsu Kaisen inspired accent color */
+  border: 1px dashed #00bfff; /* Jujutsu Kaisen inspired accent color */
 }
 
 .mob-psycho-editor {

--- a/css/cain.css
+++ b/css/cain.css
@@ -846,7 +846,6 @@
 }
 
 .mob-psycho-affliction {
-  background-color: #262626;
   padding: 5px;
   border-radius: 5px;
 }

--- a/css/cain.css
+++ b/css/cain.css
@@ -740,7 +740,6 @@
   background-color: #262626;
   padding: 10px;
   border-radius: 5px;
-  border: 1px dashed #00bfff; /* Dashed border for a report look */
 }
 
 .mob-psycho-charname input {
@@ -753,7 +752,6 @@
 .mob-psycho-grid {
   color: #ffffff;
   gap: 10px;
-  border: 1px solid #00bfff; /* Jujutsu Kaisen inspired accent color */
   padding: 10px;
   margin: 10px 0;
 }
@@ -762,7 +760,6 @@
   background-color: #333333;
   padding: 5px;
   border-radius: 5px;
-  border: 1px dashed #00bfff; /* Dashed border for a report look */
 }
 
 .mob-psycho-label {
@@ -841,7 +838,7 @@
   background-color: #262626;
   padding: 5px;
   border-radius: 5px;
-  border: 1px dashed #00bfff; /* Dashed border for a report look */
+  margin: 2px; /* Dashed border for a report look */
 }
 
 .mob-psycho-extra-dice {
@@ -855,7 +852,6 @@
   background-color: #262626;
   padding: 5px;
   border-radius: 5px;
-  border: 1px dashed #00bfff; /* Dashed border for a report look */
 }
 
 .mob-psycho-main {
@@ -945,6 +941,14 @@
 
 .message-delete {
   color: #ff4d4d; /* Red color for delete icon */
+}
+
+.no-border{
+  border: none !important;
+}
+
+.no-padding{
+  padding: none !important;
 }
 
 .flavor-text {

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} {{actor.type}} flexcol mob-psycho-theme" autocomplete="off">
+<form class="{{cssClass}} {{actor.type}} flexcol mob-psycho-theme no-border" autocomplete="off">
 
   {{!-- Sheet Header --}}
   <header class="sheet-header mob-psycho-header">
@@ -8,7 +8,7 @@
     <div class="header-fields mob-psycho-header-fields">
       <h1 class="charname mob-psycho-charname"><input name="name" type="text" value="{{actor.name}}" placeholder="Name"/></h1>
 
-      <div class="grid grid-4col mob-psycho-grid">
+      <div class="grid grid-4col">
         <div class="flex-group-center mob-psycho-flex-group">
           <label for="system.sex" class="resource-label mob-psycho-label">Sex</label>
           <input type="text" name="system.sex" value="{{system.sex}}" data-dtype="String" class="mob-psycho-input"/>
@@ -52,7 +52,9 @@
 
         <div class="flex-group-center mob-psycho-flex-group">
           <label for="system.XID" class="resource-label mob-psycho-label">XID</label>
-          <input type="text" name="system.XID" value="{{system.XID}}" data-dtype="Number" class="mob-psycho-input"/>
+          <div style="padding: 5px">
+            <input type="text" name="system.XID" value="{{system.XID}}" data-dtype="Number" class="mob-psycho-input"/>
+          </div>
         </div>
       </div>
   </header>
@@ -72,7 +74,7 @@
   <section class="sheet-body mob-psycho-body">
 
     {{!-- Owned Features Tab --}}
-    <div class="tab features mob-psycho-tab" data-group="primary" data-tab="features">
+    <div class="tab" data-group="primary" data-tab="features">
   
       <section class="grid grid-3col mob-psycho-grid">
         <aside class="sidebar mob-psycho-sidebar">
@@ -120,7 +122,7 @@
     </div>
 
     {{!-- Biography Tab --}}
-    <div class="tab biography mob-psycho-tab" data-group="primary" data-tab="description">
+    <div class="tab biography mob-psycho-tab no-border no-padding" data-group="primary" data-tab="description">
       {{!-- Editors must receive enriched text data from getData to properly handle rolls --}}
       
       {{editor enrichedBiography target="system.biography" button=True engine="prosemirror" button=true editable=editable class="mob-psycho-editor"}}

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -122,7 +122,7 @@
     </div>
 
     {{!-- Biography Tab --}}
-    <div class="tab biography mob-psycho-tab no-border no-padding" data-group="primary" data-tab="description">
+    <div class="tab biography mob-psycho-tab" data-group="primary" data-tab="description">
       {{!-- Editors must receive enriched text data from getData to properly handle rolls --}}
       
       {{editor enrichedBiography target="system.biography" button=True engine="prosemirror" button=true editable=editable class="mob-psycho-editor"}}

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -97,8 +97,8 @@
   <div class="checkbox-group checkbox-group_cat" data-field="CATLEVEL">
     {{#times 7}}
     <div class="checkbox-item checkbox-item_cat">
-      <img src="systems/cain/assets/CAT/CAT{{@index}}.png" alt="CAT {{@index}}">
-      <label for="CATLEVEL-{{@index}}">Level {{@index}}</label>
+      <img src="systems/cain/assets/CAT/CAT{{@index}}.png" class="no-border" alt="CAT {{@index}}">
+      <label class="mob-psycho-heading" for="CATLEVEL-{{@index}}">Level {{@index}}</label>
       <input type="checkbox" name="CATLEVEL-{{@index}}" {{#if (gte system.CATLEVEL.value @index)}}checked{{/if}}/>
     </div>
     {{/times}}


### PR DESCRIPTION
For improved readability I

removed borders (sometimes also backgrounds) and some padding in:
- base stat visualization (sex, height, weight, ecc)
- skill list
- afllicitions
- CAT images

removed padding on all the tabs of the character-actor sheet
changed the second column in the Stats & Advancements section to also use a dashed border

![grafik](https://github.com/user-attachments/assets/fdf6dead-305a-437a-bb84-b9a4235d9f3a)
![grafik](https://github.com/user-attachments/assets/0ed9318e-9d13-4b3d-93f2-8e3f97900d4f)
