### PR TITLE
Renamed offset to CainOffset

### DIFF
--- a/module/cain.mjs
+++ b/module/cain.mjs
@@ -326,7 +326,7 @@ Handlebars.registerHelper('json', function(context) {
   return JSON.stringify(context);
 });
 
-Handlebars.registerHelper('offset', function(value, offset, options) {
+Handlebars.registerHelper('CainOffset', function(value, offset, options) {
   if(value===undefined || offset===undefined || parseInt(value)===NaN || !parseInt(offset) === NaN){
     throw new Error(`offset helper did not receive a number: val=${value}, offset=${offset}`);
   }

--- a/templates/actor/parts/actor-sin.hbs
+++ b/templates/actor/parts/actor-sin.hbs
@@ -5,13 +5,13 @@
       {{#range 0 system.sinOverflow.max}}
         {{#if (lt index ../system.sinOverflow.value)}}
           <img 
-            class="sinOverflow-icon sinOverflow-icon-anim sin-icon-anim-{{mod (offset index ../sheetConstants.SINVisualOffset) 7}}"
-            data-sin="{{offset index 1}}"/>
+            class="sinOverflow-icon sinOverflow-icon-anim sin-icon-anim-{{mod (CainOffset index ../sheetConstants.SINVisualOffset) 7}}"
+            data-sin="{{CainOffset index 1}}"/>
         {{else}}
           <img 
             class="sinOverflow-icon"
             src="systems/cain/assets/sheet/CAIN-sin-no.png"
-            data-sin="{{offset index 1}}"/>
+            data-sin="{{CainOffset index 1}}"/>
         {{/if}}
       {{/range}}
     </div>


### PR DESCRIPTION
found that the offset helper had a naming conflict with UniversalBattlemapImporter so I renamed it to avoid that conflict.  We should figure out if we can scope things to avoid such stuff in the future.